### PR TITLE
Reduce require approval to 0 on protection branch

### DIFF
--- a/otterdog/eclipse-mylyn.jsonnet
+++ b/otterdog/eclipse-mylyn.jsonnet
@@ -61,7 +61,7 @@ orgs.newOrg('eclipse-mylyn') {
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
-          required_approving_review_count: 1,
+          required_approving_review_count: 0,
           requires_status_checks: false,
           requires_strict_status_checks: true,
         },


### PR DESCRIPTION
This PR set explicitly the number of required approval to 0 protected branches.

There is an automated workflow running that will validate the PR and show the changes that will be performed once its merged, see the comment to review the settings.

The list of supported settings can be found here: https://gitlab.eclipse.org/eclipsefdn/security/otterdog/-/tree/main#supported-settings

Related to https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3421